### PR TITLE
Solves Issue #6:  Added html2pdf library so that users can download the resume as pdf

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,30 +9,31 @@
 <body>
   <div id="resume-form">
     <h1>Personal Information</h1>
-    <input type="text" name="name" placeholder="Name">
-    <input type="text" name="email" placeholder="Email">
-    <input type="text" name="phone" placeholder="Phone">
-    <input type="text" name="address" placeholder="Address">
+    <input id="name" type="text" name="name" placeholder="Name">
+    <input id="email" type="text" name="email" placeholder="Email">
+    <input id="phone" type="text" name="phone" placeholder="Phone">
+    <input id="address" type="text" name="address" placeholder="Address">
     <h1>Education</h1>
-    <input type="text" name="school" placeholder="School">
-    <input type="text" name="degree" placeholder="Degree">
-    <input type="text" name="major" placeholder="Major">
-    <input type="text" name="graduation-date" placeholder="Graduation Date">
+    <input id="school" type="text" name="school" placeholder="School">
+    <input id="degree" type="text" name="degree" placeholder="Degree">
+    <input id="major" type="text" name="major" placeholder="Major">
+    <input id="graduation-date" type="text" name="graduation-date" placeholder="Graduation Date">
     <h1>Work Experience</h1>
-    <input type="text" name="company" placeholder="Company">
-    <input type="text" name="title" placeholder="Title">
-    <input type="text" name="start-date" placeholder="Start Date">
-    <input type="text" name="end-date" placeholder="End Date">
+    <input id="company" type="text" name="company" placeholder="Company">
+    <input id="title" type="text" name="title" placeholder="Title">
+    <input id="start-date" type="text" name="start-date" placeholder="Start Date">
+    <input id="end-date" type="text" name="end-date" placeholder="End Date">
     <h1>Skills</h1>
-    <input type="text" name="skill-1" placeholder="Skill 1">
-    <input type="text" name="skill-2" placeholder="Skill 2">
-    <input type="text" name="skill-3" placeholder="Skill 3">
+    <input id="skill-1" type="text" name="skill-1" placeholder="Skill 1">
+    <input id="skill-2" type="text" name="skill-2" placeholder="Skill 2">
+    <input id="skill-3" type="text" name="skill-3" placeholder="Skill 3">
     <h1>References</h1>
-    <input type="text" name="reference-1" placeholder="Reference 1">
-    <input type="text" name="reference-2" placeholder="Reference 2">
-    <input type="text" name="reference-3" placeholder="Reference 3">
+    <input id="reference-1" type="text" name="reference-1" placeholder="Reference 1">
+    <input id="reference-2" type="text" name="reference-2" placeholder="Reference 2">
+    <input id="reference-3" type="text" name="reference-3" placeholder="Reference 3">
     <button id="download-button">Download PDF</button>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.2/html2pdf.bundle.js"></script>
   <script src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -85,11 +85,18 @@ downloadButton.addEventListener('click', () => {
     </body>
     </html>
   `;
-  const resumeBlob = new Blob([resumeTemplate], { type : 'text/html' });
-  const resumeUrl = URL.createObjectURL(resumeBlob);
-  const resumeLink = document.createElement('a');
-  resumeLink.href = resumeUrl;
-  resumeLink.download = 'resume.html';
-  resumeLink.click();
-  URL.revokeObjectURL(resumeUrl);
+
+  const element = document.createElement('div');
+  element.innerHTML = resumeTemplate;
+
+  html2pdf(element, {
+    margin: 10,
+    filename: 'resume.pdf',
+    image: { type: 'jpeg', quality: 0.98 },
+    html2canvas: { scale: 2 },
+    jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
+  }).then(function(pdf) {
+    pdf.save('resume.pdf');
+  });
+
 })


### PR DESCRIPTION
This PR solves the issue #6 

I first added the id attribute in HTML input tags so that the document.getElementById is able to select the input components earlier it was not able to and then I added the html2pdf library.

The html2pdf library downloads the resume in PDF format which was an HTML document earlier.

See,
![proof-pdf-resume](https://github.com/koalalu007/resume-maker/assets/117712672/c951b28d-88f5-492a-aba8-fc38035bad6f)
